### PR TITLE
Dodaj funkcjonalność ulubionych do głównej karty

### DIFF
--- a/StoryEditor/Goal.cs
+++ b/StoryEditor/Goal.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace StoryEditor
+{
+    public class Goal
+    {
+        public List<int> parent = new List<int>();
+        public List<int> child = new List<int>();
+        public int ID;
+        public string NAME = "";
+        public List<string> INIT = new List<string>();
+        public List<string> KB = new List<string>();
+        public List<string> EXIT = new List<string>();
+        public Goal(int id, string name)
+        {
+            ID = id;
+            NAME = name;
+        }
+        public Goal(int id, string name, List<string> init, List<string> kb, List<string> exit)
+        {
+            ID = id;
+            NAME = name;
+            INIT = init;
+            KB = kb;
+            EXIT = exit;
+        }
+        public void ClearParentAndChild()
+        {
+            parent.Clear();
+            child.Clear();
+        }
+    }
+}

--- a/StoryEditor/MainForm.Designer.cs
+++ b/StoryEditor/MainForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace StoryEditor
+namespace StoryEditor
 {
     partial class MainForm
     {
@@ -45,6 +45,8 @@
             MainControlPanel = new TabControl();
             MAIN = new TabPage();
             MAINSplitContainer = new SplitContainer();
+            FavoritesListBox = new ListBox();
+            FavoritesLabel = new Label();
             GoalTreeView = new TreeView();
             panel1 = new Panel();
             addRuleButton = new Button();
@@ -302,6 +304,8 @@
             // 
             // MAINSplitContainer.Panel1
             // 
+            MAINSplitContainer.Panel1.Controls.Add(FavoritesListBox);
+            MAINSplitContainer.Panel1.Controls.Add(FavoritesLabel);
             MAINSplitContainer.Panel1.Controls.Add(GoalTreeView);
             MAINSplitContainer.Panel1.Controls.Add(panel1);
             // 
@@ -312,13 +316,36 @@
             MAINSplitContainer.SplitterDistance = 498;
             MAINSplitContainer.TabIndex = 1;
             // 
+            // FavoritesListBox
+            // 
+            FavoritesListBox.Font = new Font("Consolas", 10.2F);
+            FavoritesListBox.FormattingEnabled = true;
+            FavoritesListBox.ItemHeight = 17;
+            FavoritesListBox.Location = new Point(0, 30);
+            FavoritesListBox.Margin = new Padding(3, 2, 3, 2);
+            FavoritesListBox.Name = "FavoritesListBox";
+            FavoritesListBox.Size = new Size(496, 100);
+            FavoritesListBox.TabIndex = 0;
+            // 
+            // FavoritesLabel
+            // 
+            FavoritesLabel.AutoSize = true;
+            FavoritesLabel.Location = new Point(3, 10);
+            FavoritesLabel.Margin = new Padding(3, 0, 3, 0);
+            FavoritesLabel.Name = "FavoritesLabel";
+            FavoritesLabel.Size = new Size(100, 15);
+            FavoritesLabel.TabIndex = 1;
+            FavoritesLabel.Text = "Favorites List";
+            // 
             // GoalTreeView
             // 
-            GoalTreeView.Dock = DockStyle.Fill;
-            GoalTreeView.Location = new Point(0, 23);
+            GoalTreeView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            GoalTreeView.Location = new Point(0, 140);
             GoalTreeView.Margin = new Padding(3, 2, 3, 2);
             GoalTreeView.Name = "GoalTreeView";
-            GoalTreeView.Size = new Size(496, 623);
+            GoalTreeView.Size = new Size(496, 506);
             GoalTreeView.TabIndex = 2;
             GoalTreeView.AfterSelect += GoalTreeView_AfterSelect;
             // 
@@ -1060,5 +1087,7 @@
         private TreeView GoalTreeView;
         private ComboBox FilterComboBox;
         private Button addRuleButton;
+        private ListBox FavoritesListBox;
+        private Label FavoritesLabel;
     }
 }

--- a/StoryEditor/MainForm.Designer.cs
+++ b/StoryEditor/MainForm.Designer.cs
@@ -326,6 +326,7 @@ namespace StoryEditor
             FavoritesListBox.Name = "FavoritesListBox";
             FavoritesListBox.Size = new Size(496, 100);
             FavoritesListBox.TabIndex = 0;
+            FavoritesListBox.DoubleClick += FavoritesListBox_DoubleClick;
             // 
             // FavoritesLabel
             // 

--- a/StoryEditor/MainForm.Designer.cs
+++ b/StoryEditor/MainForm.Designer.cs
@@ -304,9 +304,9 @@ namespace StoryEditor
             // 
             // MAINSplitContainer.Panel1
             // 
+            MAINSplitContainer.Panel1.Controls.Add(GoalTreeView);
             MAINSplitContainer.Panel1.Controls.Add(FavoritesListBox);
             MAINSplitContainer.Panel1.Controls.Add(FavoritesLabel);
-            MAINSplitContainer.Panel1.Controls.Add(GoalTreeView);
             MAINSplitContainer.Panel1.Controls.Add(panel1);
             // 
             // MAINSplitContainer.Panel2
@@ -316,38 +316,34 @@ namespace StoryEditor
             MAINSplitContainer.SplitterDistance = 498;
             MAINSplitContainer.TabIndex = 1;
             // 
-            // FavoritesListBox
-            // 
-            FavoritesListBox.Font = new Font("Consolas", 10.2F);
-            FavoritesListBox.FormattingEnabled = true;
-            FavoritesListBox.ItemHeight = 17;
-            FavoritesListBox.Location = new Point(0, 30);
-            FavoritesListBox.Margin = new Padding(3, 2, 3, 2);
-            FavoritesListBox.Name = "FavoritesListBox";
-            FavoritesListBox.Size = new Size(496, 100);
-            FavoritesListBox.TabIndex = 0;
-            FavoritesListBox.DoubleClick += FavoritesListBox_DoubleClick;
-            // 
             // FavoritesLabel
             // 
             FavoritesLabel.AutoSize = true;
-            FavoritesLabel.Location = new Point(3, 10);
-            FavoritesLabel.Margin = new Padding(3, 0, 3, 0);
+            FavoritesLabel.Location = new Point(3, 30);
             FavoritesLabel.Name = "FavoritesLabel";
-            FavoritesLabel.Size = new Size(100, 15);
-            FavoritesLabel.TabIndex = 1;
+            FavoritesLabel.Size = new Size(80, 15);
+            FavoritesLabel.TabIndex = 3;
             FavoritesLabel.Text = "Favorites List";
+            // 
+            // FavoritesListBox
+            // 
+            FavoritesListBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            FavoritesListBox.Font = new Font("Consolas", 10.2F);
+            FavoritesListBox.FormattingEnabled = true;
+            FavoritesListBox.ItemHeight = 17;
+            FavoritesListBox.Location = new Point(0, 50);
+            FavoritesListBox.Name = "FavoritesListBox";
+            FavoritesListBox.Size = new Size(496, 85);
+            FavoritesListBox.TabIndex = 4;
+            FavoritesListBox.DoubleClick += FavoritesListBox_DoubleClick;
             // 
             // GoalTreeView
             // 
-            GoalTreeView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            GoalTreeView.Location = new Point(0, 140);
-            GoalTreeView.Margin = new Padding(3, 2, 3, 2);
+            GoalTreeView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            GoalTreeView.Location = new Point(0, 135);
             GoalTreeView.Name = "GoalTreeView";
-            GoalTreeView.Size = new Size(496, 506);
-            GoalTreeView.TabIndex = 2;
+            GoalTreeView.Size = new Size(496, 511);
+            GoalTreeView.TabIndex = 5;
             GoalTreeView.AfterSelect += GoalTreeView_AfterSelect;
             // 
             // panel1
@@ -356,7 +352,6 @@ namespace StoryEditor
             panel1.Controls.Add(FilterComboBox);
             panel1.Dock = DockStyle.Top;
             panel1.Location = new Point(0, 0);
-            panel1.Margin = new Padding(3, 2, 3, 2);
             panel1.Name = "panel1";
             panel1.Size = new Size(496, 23);
             panel1.TabIndex = 0;

--- a/StoryEditor/MainForm.cs
+++ b/StoryEditor/MainForm.cs
@@ -988,6 +988,12 @@ namespace StoryEditor
                 if (foundNode != null)
                 {
                     GoalTreeView.SelectedNode = foundNode;
+                    GoalTreeView.Focus();
+                    foundNode.EnsureVisible();
+                    
+                    // Odczytujemy goal, aby pokazać jego zawartość
+                    selectedGoal = goalId - 1;
+                    ReadGoal(selectedGoal);
                 }
             }
         }

--- a/StoryEditor/MainForm.cs
+++ b/StoryEditor/MainForm.cs
@@ -37,9 +37,9 @@ namespace StoryEditor
         public static List<string> rules_query = new List<string>();
         public static List<string> rules_syscall = new List<string>();
         public static List<string> rules_sysquery = new List<string>();
-        // Lista ulubionych elementów
-        public static List<Objects> favoriteObjects = new List<Objects>();
-        private ContextMenuStrip mainListContextMenu = new ContextMenuStrip();
+        // Lista ulubionych celów
+        public static List<Goal> favoriteGoals = new List<Goal>();
+        private ContextMenuStrip treeViewContextMenu = new ContextMenuStrip();
         private string stringFilter = "";
         public int selectedGoal = -1;
         public bool compile_trace = false;
@@ -91,11 +91,11 @@ namespace StoryEditor
                 }
             }
             
-            // Inicjalizacja menu kontekstowego dla elementów w zakładce MAIN
-            mainListContextMenu = new ContextMenuStrip();
+            // Inicjalizacja menu kontekstowego dla GoalTreeView
+            treeViewContextMenu = new ContextMenuStrip();
             ToolStripMenuItem addToFavoritesMenuItem = new ToolStripMenuItem("Dodaj do ulubionych");
             addToFavoritesMenuItem.Click += AddToFavoritesMenuItem_Click;
-            mainListContextMenu.Items.Add(addToFavoritesMenuItem);
+            treeViewContextMenu.Items.Add(addToFavoritesMenuItem);
             
             // Inicjalizacja menu kontekstowego dla listy ulubionych
             ContextMenuStrip favoritesContextMenu = new ContextMenuStrip();
@@ -103,19 +103,8 @@ namespace StoryEditor
             removeFromFavoritesMenuItem.Click += RemoveFromFavoritesMenuItem_Click;
             favoritesContextMenu.Items.Add(removeFromFavoritesMenuItem);
             
-            // Przypisanie menu kontekstowego do kontrolek ListBox
-            NPCListBox.ContextMenuStrip = mainListContextMenu;
-            OBJECTListBox.ContextMenuStrip = mainListContextMenu;
-            DIALOGListBox.ContextMenuStrip = mainListContextMenu;
-            REGIONListBox.ContextMenuStrip = mainListContextMenu;
-            LOCATIONListBox.ContextMenuStrip = mainListContextMenu;
-            NPC_CLASSListBox.ContextMenuStrip = mainListContextMenu;
-            OBJECT_CLASSListBox.ContextMenuStrip = mainListContextMenu;
-            DIALOG_EVENTListBox.ContextMenuStrip = mainListContextMenu;
-            ENGINEListBox.ContextMenuStrip = mainListContextMenu;
-            FUNCTIONListBox.ContextMenuStrip = mainListContextMenu;
-            SREGIONListBox.ContextMenuStrip = mainListContextMenu;
-            
+            // Przypisanie menu kontekstowego
+            GoalTreeView.ContextMenuStrip = treeViewContextMenu;
             FavoritesListBox.ContextMenuStrip = favoritesContextMenu;
             
             // Wczytywanie ulubionych przy starcie aplikacji
@@ -935,9 +924,9 @@ namespace StoryEditor
                 string favoritesFile = "favorites.txt";
                 List<string> favLines = new List<string>();
                 
-                foreach (var favorite in favoriteObjects)
+                foreach (var favorite in favoriteGoals)
                 {
-                    favLines.Add(favorite.name + "|" + favorite.type + "|" + favorite.ID);
+                    favLines.Add(favorite.ID + "|" + favorite.NAME);
                 }
                 
                 File.WriteAllLines(favoritesFile, favLines);
@@ -958,17 +947,24 @@ namespace StoryEditor
                 try
                 {
                     string[] lines = File.ReadAllLines(favoritesFile);
-                    favoriteObjects.Clear();
+                    favoriteGoals.Clear();
                     FavoritesListBox.Items.Clear();
                     
                     foreach (string line in lines)
                     {
                         string[] parts = line.Split('|');
-                        if (parts.Length == 3)
+                        if (parts.Length == 2)
                         {
-                            Objects obj = new Objects(parts[0], parts[1], parts[2]);
-                            favoriteObjects.Add(obj);
-                            FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                            int goalId = int.Parse(parts[0]);
+                            string goalName = parts[1];
+                            
+                            // Szukamy celu w głównej liście celów
+                            Goal goal = goals.FirstOrDefault(g => g.ID == goalId);
+                            if (goal != null)
+                            {
+                                favoriteGoals.Add(goal);
+                                FavoritesListBox.Items.Add(goalId + " " + goalName);
+                            }
                         }
                     }
                     ConsoleRichTextBox.AppendText("Ulubione wczytane\n");
@@ -979,7 +975,41 @@ namespace StoryEditor
                 }
             }
         }
-
+        
+        // Dodanie obsługi podwójnego kliknięcia na element w liście ulubionych
+        private void FavoritesListBox_DoubleClick(object sender, EventArgs e)
+        {
+            if (FavoritesListBox.SelectedItem != null)
+            {
+                string selectedItem = FavoritesListBox.SelectedItem.ToString();
+                int goalId = int.Parse(selectedItem.Split(' ')[0]);
+                
+                TreeNode foundNode = FindNodeByGoalId(GoalTreeView.Nodes, goalId);
+                if (foundNode != null)
+                {
+                    GoalTreeView.SelectedNode = foundNode;
+                }
+            }
+        }
+        
+        private TreeNode FindNodeByGoalId(TreeNodeCollection nodes, int goalId)
+        {
+            foreach (TreeNode node in nodes)
+            {
+                if (node.Tag != null && int.Parse(node.Tag.ToString()) == goalId)
+                {
+                    return node;
+                }
+                
+                TreeNode childNode = FindNodeByGoalId(node.Nodes, goalId);
+                if (childNode != null)
+                {
+                    return childNode;
+                }
+            }
+            
+            return null;
+        }
         //---------------------------------------------------------------------------------------
         private void FilterComboBox_TextUpdate(object sender, EventArgs e)
         {
@@ -1053,146 +1083,15 @@ namespace StoryEditor
 
         private void AddToFavoritesMenuItem_Click(object? sender, EventArgs e)
         {
-            if (NPCListBox.SelectedItem is not null)
+            if (GoalTreeView.SelectedNode != null)
             {
-                string[] selectedItem = NPCListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "4", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                int goalId = int.Parse(GoalTreeView.SelectedNode.Tag.ToString());
+                Goal goalToAdd = goals.FirstOrDefault(g => g.ID == goalId);
+                
+                if (goalToAdd != null && !favoriteGoals.Any(f => f.ID == goalToAdd.ID))
                 {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (OBJECTListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = OBJECTListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "5", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (DIALOGListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = DIALOGListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "6", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (REGIONListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = REGIONListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "7", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (LOCATIONListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = LOCATIONListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "8", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (NPC_CLASSListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = NPC_CLASSListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "9", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (OBJECT_CLASSListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = OBJECT_CLASSListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "10", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (DIALOG_EVENTListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = DIALOG_EVENTListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "11", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (ENGINEListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = ENGINEListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "12", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (FUNCTIONListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = FUNCTIONListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "13", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
-                    SaveFavorites();
-                }
-            }
-            else if (SREGIONListBox.SelectedItem is not null)
-            {
-                string[] selectedItem = SREGIONListBox.SelectedItem.ToString().Split(' ');
-                int id = Int32.Parse(selectedItem[0]);
-                string name = selectedItem[1];
-                Objects obj = new Objects(name, "15", id.ToString());
-                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
-                {
-                    favoriteObjects.Add(obj);
-                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    favoriteGoals.Add(goalToAdd);
+                    FavoritesListBox.Items.Add(goalToAdd.ID + " " + goalToAdd.NAME);
                     SaveFavorites();
                 }
             }
@@ -1200,14 +1099,15 @@ namespace StoryEditor
 
         private void RemoveFromFavoritesMenuItem_Click(object? sender, EventArgs e)
         {
-            if (FavoritesListBox.SelectedItem is not null)
+            if (FavoritesListBox.SelectedItem != null)
             {
                 string selectedItem = FavoritesListBox.SelectedItem.ToString();
-                int id = Int32.Parse(selectedItem.Split(' ')[0]);
-                Objects objToRemove = favoriteObjects.FirstOrDefault(f => f.ID == id);
-                if (objToRemove != null)
+                int goalId = int.Parse(selectedItem.Split(' ')[0]);
+                
+                Goal goalToRemove = favoriteGoals.FirstOrDefault(g => g.ID == goalId);
+                if (goalToRemove != null)
                 {
-                    favoriteObjects.Remove(objToRemove);
+                    favoriteGoals.Remove(goalToRemove);
                     FavoritesListBox.Items.Remove(FavoritesListBox.SelectedItem);
                     SaveFavorites();
                 }

--- a/StoryEditor/MainForm.cs
+++ b/StoryEditor/MainForm.cs
@@ -39,6 +39,8 @@ namespace StoryEditor
         public static List<string> rules_sysquery = new List<string>();
         // Lista ulubionych celów
         public static List<Goal> favoriteGoals = new List<Goal>();
+        // Lista ID ulubionych celów (używana do przechowywania ID nawet gdy lista goals jest pusta)
+        public static List<int> favoriteGoalIds = new List<int>();
         private ContextMenuStrip treeViewContextMenu = new ContextMenuStrip();
         private string stringFilter = "";
         public int selectedGoal = -1;
@@ -107,7 +109,7 @@ namespace StoryEditor
             GoalTreeView.ContextMenuStrip = treeViewContextMenu;
             FavoritesListBox.ContextMenuStrip = favoritesContextMenu;
             
-            // Wczytywanie ulubionych przy starcie aplikacji
+            // Wczytywanie ulubionych przy starcie aplikacji (tylko ID)
             LoadFavorites();
             
             //  
@@ -362,6 +364,9 @@ namespace StoryEditor
             selectedGoal = 0;
             ReadGoal(0);
             addRuleButton.Enabled = true;
+            
+            // Odświeżamy listę ulubionych po wczytaniu story
+            RefreshFavorites();
         }
         //---------------------------------------------------------------------------------------
         private void SaveStory(
@@ -924,9 +929,9 @@ namespace StoryEditor
                 string favoritesFile = "favorites.txt";
                 List<string> favLines = new List<string>();
                 
-                foreach (var favorite in favoriteGoals)
+                foreach (var favoriteId in favoriteGoalIds)
                 {
-                    favLines.Add(favorite.ID + "|" + favorite.NAME);
+                    favLines.Add(favoriteId.ToString());
                 }
                 
                 File.WriteAllLines(favoritesFile, favLines);
@@ -947,31 +952,37 @@ namespace StoryEditor
                 try
                 {
                     string[] lines = File.ReadAllLines(favoritesFile);
-                    favoriteGoals.Clear();
-                    FavoritesListBox.Items.Clear();
+                    favoriteGoalIds.Clear();
                     
                     foreach (string line in lines)
                     {
-                        string[] parts = line.Split('|');
-                        if (parts.Length == 2)
+                        if (int.TryParse(line, out int goalId))
                         {
-                            int goalId = int.Parse(parts[0]);
-                            string goalName = parts[1];
-                            
-                            // Szukamy celu w głównej liście celów
-                            Goal goal = goals.FirstOrDefault(g => g.ID == goalId);
-                            if (goal != null)
-                            {
-                                favoriteGoals.Add(goal);
-                                FavoritesListBox.Items.Add(goalId + " " + goalName);
-                            }
+                            favoriteGoalIds.Add(goalId);
                         }
                     }
-                    ConsoleRichTextBox.AppendText("Ulubione wczytane\n");
+                    ConsoleRichTextBox.AppendText("ID ulubionych wczytane\n");
                 }
                 catch (Exception ex)
                 {
                     ConsoleRichTextBox.AppendText("Błąd wczytywania ulubionych: " + ex.Message + "\n");
+                }
+            }
+        }
+        
+        // Metoda odświeżająca listę ulubionych na podstawie ID i aktualnej listy goals
+        private void RefreshFavorites()
+        {
+            favoriteGoals.Clear();
+            FavoritesListBox.Items.Clear();
+            
+            foreach (int favoriteId in favoriteGoalIds)
+            {
+                Goal goal = goals.FirstOrDefault(g => g.ID == favoriteId);
+                if (goal != null)
+                {
+                    favoriteGoals.Add(goal);
+                    FavoritesListBox.Items.Add(goal.ID + " " + goal.NAME);
                 }
             }
         }
@@ -1094,8 +1105,9 @@ namespace StoryEditor
                 int goalId = int.Parse(GoalTreeView.SelectedNode.Tag.ToString());
                 Goal goalToAdd = goals.FirstOrDefault(g => g.ID == goalId);
                 
-                if (goalToAdd != null && !favoriteGoals.Any(f => f.ID == goalToAdd.ID))
+                if (goalToAdd != null && !favoriteGoalIds.Contains(goalId))
                 {
+                    favoriteGoalIds.Add(goalId);
                     favoriteGoals.Add(goalToAdd);
                     FavoritesListBox.Items.Add(goalToAdd.ID + " " + goalToAdd.NAME);
                     SaveFavorites();
@@ -1110,13 +1122,15 @@ namespace StoryEditor
                 string selectedItem = FavoritesListBox.SelectedItem.ToString();
                 int goalId = int.Parse(selectedItem.Split(' ')[0]);
                 
+                favoriteGoalIds.Remove(goalId);
                 Goal goalToRemove = favoriteGoals.FirstOrDefault(g => g.ID == goalId);
                 if (goalToRemove != null)
                 {
                     favoriteGoals.Remove(goalToRemove);
-                    FavoritesListBox.Items.Remove(FavoritesListBox.SelectedItem);
-                    SaveFavorites();
                 }
+                
+                FavoritesListBox.Items.Remove(FavoritesListBox.SelectedItem);
+                SaveFavorites();
             }
         }
     }

--- a/StoryEditor/MainForm.cs
+++ b/StoryEditor/MainForm.cs
@@ -37,6 +37,9 @@ namespace StoryEditor
         public static List<string> rules_query = new List<string>();
         public static List<string> rules_syscall = new List<string>();
         public static List<string> rules_sysquery = new List<string>();
+        // Lista ulubionych elementГіw
+        public static List<Objects> favoriteObjects = new List<Objects>();
+        private ContextMenuStrip mainListContextMenu = new ContextMenuStrip();
         private string stringFilter = "";
         public int selectedGoal = -1;
         public bool compile_trace = false;
@@ -48,7 +51,7 @@ namespace StoryEditor
         {
             InitializeComponent();
             pathToMainProgramFolder = AppDomain.CurrentDomain.BaseDirectory;
-            // Читаем rules
+            // пїЅпїЅпїЅпїЅпїЅпїЅ rules
             if (File.Exists("rules.000"))
             {
                 string[] lines = File.ReadLines("rules.000").ToArray();
@@ -87,7 +90,38 @@ namespace StoryEditor
                     }
                 }
             }
-            // Читаем конфиг
+            
+            // Inicjalizacja menu kontekstowego dla elementГіw w zakЕ‚adce MAIN
+            mainListContextMenu = new ContextMenuStrip();
+            ToolStripMenuItem addToFavoritesMenuItem = new ToolStripMenuItem("Dodaj do ulubionych");
+            addToFavoritesMenuItem.Click += AddToFavoritesMenuItem_Click;
+            mainListContextMenu.Items.Add(addToFavoritesMenuItem);
+            
+            // Inicjalizacja menu kontekstowego dla listy ulubionych
+            ContextMenuStrip favoritesContextMenu = new ContextMenuStrip();
+            ToolStripMenuItem removeFromFavoritesMenuItem = new ToolStripMenuItem("UsuЕ„ z ulubionych");
+            removeFromFavoritesMenuItem.Click += RemoveFromFavoritesMenuItem_Click;
+            favoritesContextMenu.Items.Add(removeFromFavoritesMenuItem);
+            
+            // Przypisanie menu kontekstowego do kontrolek ListBox
+            NPCListBox.ContextMenuStrip = mainListContextMenu;
+            OBJECTListBox.ContextMenuStrip = mainListContextMenu;
+            DIALOGListBox.ContextMenuStrip = mainListContextMenu;
+            REGIONListBox.ContextMenuStrip = mainListContextMenu;
+            LOCATIONListBox.ContextMenuStrip = mainListContextMenu;
+            NPC_CLASSListBox.ContextMenuStrip = mainListContextMenu;
+            OBJECT_CLASSListBox.ContextMenuStrip = mainListContextMenu;
+            DIALOG_EVENTListBox.ContextMenuStrip = mainListContextMenu;
+            ENGINEListBox.ContextMenuStrip = mainListContextMenu;
+            FUNCTIONListBox.ContextMenuStrip = mainListContextMenu;
+            SREGIONListBox.ContextMenuStrip = mainListContextMenu;
+            
+            FavoritesListBox.ContextMenuStrip = favoritesContextMenu;
+            
+            // Wczytywanie ulubionych przy starcie aplikacji
+            LoadFavorites();
+            
+            //  
             if (File.Exists("config.ini"))
             {
                 string[] lines = File.ReadLines("config.ini").ToArray();
@@ -169,7 +203,7 @@ namespace StoryEditor
             ConsoleRichTextBox.AppendText("Path to div.exe: " + pathToDivFile + "\n");
             ConsoleRichTextBox.AppendText("Path to story.000: " + pathToStoryBinFile + "\n");
             //---------------------------------------------------------------------------------------
-            // Добавляем элементы в контекстное меню для области KB
+            // пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ KB
             KBRichTextBox.ContextMenuStrip = KBContextMenuStrip;
             ToolStripMenuItem Call = new ToolStripMenuItem("Call");
             ToolStripMenuItem Event = new ToolStripMenuItem("Event");
@@ -592,7 +626,7 @@ namespace StoryEditor
             SaveStory(pathToStoryFile, compile_trace, debug_trace, objects, goals, storyVersion);
         }
         //---------------------------------------------------------------------------------------
-        private void BuildButton_Click(object sender, EventArgs e) // Сохраняем и компилируем бинарник
+        private void BuildButton_Click(object sender, EventArgs e) // пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
         {
             if (selectedGoal >= 0)
             {
@@ -619,7 +653,7 @@ namespace StoryEditor
                 }
                 if (ready)
                 {
-                    if (build_and_run_game) // Запускаем игру
+                    if (build_and_run_game) // пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ
                     {
                         Environment.CurrentDirectory = pathToMainProgramFolder;
                         ProcessStartInfo BuildStory = new()
@@ -892,6 +926,60 @@ namespace StoryEditor
             EXITRichTextBox.Text += buffer;
             ColoredWords();
         }
+        
+        // Metoda zapisujД…ca ulubione elementy do pliku
+        private void SaveFavorites()
+        {
+            try
+            {
+                string favoritesFile = "favorites.txt";
+                List<string> favLines = new List<string>();
+                
+                foreach (var favorite in favoriteObjects)
+                {
+                    favLines.Add(favorite.name + "|" + favorite.type + "|" + favorite.ID);
+                }
+                
+                File.WriteAllLines(favoritesFile, favLines);
+                ConsoleRichTextBox.AppendText("Ulubione zapisane\n");
+            }
+            catch (Exception ex)
+            {
+                ConsoleRichTextBox.AppendText("BЕ‚Д…d zapisywania ulubionych: " + ex.Message + "\n");
+            }
+        }
+        
+        // Metoda wczytujД…ca ulubione elementy z pliku
+        private void LoadFavorites()
+        {
+            string favoritesFile = "favorites.txt";
+            if (File.Exists(favoritesFile))
+            {
+                try
+                {
+                    string[] lines = File.ReadAllLines(favoritesFile);
+                    favoriteObjects.Clear();
+                    FavoritesListBox.Items.Clear();
+                    
+                    foreach (string line in lines)
+                    {
+                        string[] parts = line.Split('|');
+                        if (parts.Length == 3)
+                        {
+                            Objects obj = new Objects(parts[0], parts[1], parts[2]);
+                            favoriteObjects.Add(obj);
+                            FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                        }
+                    }
+                    ConsoleRichTextBox.AppendText("Ulubione wczytane\n");
+                }
+                catch (Exception ex)
+                {
+                    ConsoleRichTextBox.AppendText("BЕ‚Д…d wczytywania ulubionych: " + ex.Message + "\n");
+                }
+            }
+        }
+
         //---------------------------------------------------------------------------------------
         private void FilterComboBox_TextUpdate(object sender, EventArgs e)
         {
@@ -962,45 +1050,168 @@ namespace StoryEditor
             AR.ShowDialog();
             GoalTree();
         }
-    }
-    public class Goal
-    {
-        public List<int> parent = new List<int>();
-        public List<int> child = new List<int>();
-        public int ID;
-        public string NAME = "";
-        public List<string> INIT = new List<string>();
-        public List<string> KB = new List<string>();
-        public List<string> EXIT = new List<string>();
-        public Goal(int id, string name)
+
+        private void AddToFavoritesMenuItem_Click(object? sender, EventArgs e)
         {
-            ID = id;
-            NAME = name;
+            if (NPCListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = NPCListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "4", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (OBJECTListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = OBJECTListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "5", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (DIALOGListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = DIALOGListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "6", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (REGIONListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = REGIONListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "7", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (LOCATIONListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = LOCATIONListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "8", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (NPC_CLASSListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = NPC_CLASSListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "9", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (OBJECT_CLASSListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = OBJECT_CLASSListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "10", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (DIALOG_EVENTListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = DIALOG_EVENTListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "11", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (ENGINEListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = ENGINEListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "12", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (FUNCTIONListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = FUNCTIONListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "13", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
+            else if (SREGIONListBox.SelectedItem is not null)
+            {
+                string[] selectedItem = SREGIONListBox.SelectedItem.ToString().Split(' ');
+                int id = Int32.Parse(selectedItem[0]);
+                string name = selectedItem[1];
+                Objects obj = new Objects(name, "15", id.ToString());
+                if (!favoriteObjects.Any(f => f.ID == obj.ID && f.type == obj.type))
+                {
+                    favoriteObjects.Add(obj);
+                    FavoritesListBox.Items.Add(obj.ID.ToString().PadRight(6, ' ') + obj.name);
+                    SaveFavorites();
+                }
+            }
         }
-        public Goal(int id, string name, List<string> init, List<string> kb, List<string> exit)
+
+        private void RemoveFromFavoritesMenuItem_Click(object? sender, EventArgs e)
         {
-            ID = id;
-            NAME = name;
-            INIT = init;
-            KB = kb;
-            EXIT = exit;
-        }
-        public void ClearParentAndChild()
-        {
-            parent.Clear();
-            child.Clear();
-        }
-    }
-    public class Objects
-    {
-        public string name = "";
-        public int type;
-        public int ID;
-        public Objects(string name, string type, string ID)
-        {
-            this.name = name;
-            this.type = Int32.Parse(type);
-            this.ID = Int32.Parse(ID);
+            if (FavoritesListBox.SelectedItem is not null)
+            {
+                string selectedItem = FavoritesListBox.SelectedItem.ToString();
+                int id = Int32.Parse(selectedItem.Split(' ')[0]);
+                Objects objToRemove = favoriteObjects.FirstOrDefault(f => f.ID == id);
+                if (objToRemove != null)
+                {
+                    favoriteObjects.Remove(objToRemove);
+                    FavoritesListBox.Items.Remove(FavoritesListBox.SelectedItem);
+                    SaveFavorites();
+                }
+            }
         }
     }
 }

--- a/StoryEditor/Objects.cs
+++ b/StoryEditor/Objects.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace StoryEditor
+{
+    public class Objects
+    {
+        public string name = "";
+        public int type;
+        public int ID;
+        public Objects(string name, string type, string ID)
+        {
+            this.name = name;
+            this.type = Int32.Parse(type);
+            this.ID = Int32.Parse(ID);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+            
+            Objects other = (Objects)obj;
+            return (ID == other.ID) && (type == other.type);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(ID, type);
+        }
+    }
+}

--- a/StoryEditor/StoryEditor.csproj
+++ b/StoryEditor/StoryEditor.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -7,8 +7,8 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>bin\divicon.ico</ApplicationIcon>
-	<ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
-	<ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
+    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+    <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Implement a favorites feature for GoalTreeView items in the MAIN tab.

This PR introduces a 'Favorites List' above the GoalTreeView in the MAIN tab, allowing users to add/remove goals via context menus. Double-clicking a favorite item navigates to its original position in the GoalTreeView. A key fix addresses an issue where favorites were not correctly loaded on startup because they were attempted to be resolved before the main goal list was populated. Now, only favorite IDs are loaded initially, and the full favorite list is refreshed once the goals are available.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-5cdc5925-3780-4785-9943-12748424238a) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-5cdc5925-3780-4785-9943-12748424238a)